### PR TITLE
Fix card component class names

### DIFF
--- a/src/components/custom-ui/card.tsx
+++ b/src/components/custom-ui/card.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
 
 interface CardProps {
   children: ReactNode;
@@ -8,7 +9,10 @@ interface CardProps {
 export default function Card({ children, className }: CardProps) {
   return (
     <div
-      className={`relative bg-card/30 backdrop-blur-md rounded-xl p-6 border transition-all hover:shadow-lg hover:shadow-shadowColor ${className}`}
+      className={cn(
+        "relative bg-card/30 backdrop-blur-md rounded-xl p-6 border transition-all hover:shadow-lg hover:shadow-shadowColor",
+        className,
+      )}
     >
       {children}
     </div>


### PR DESCRIPTION
## Summary
- fix Card component to avoid 'undefined' CSS class when no className is provided

## Testing
- `pnpm lint`
- `pnpm types`
