### PR TITLE
Fix type mismatch in blog post page

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -16,10 +16,10 @@ import { Suspense } from "react";
 export async function generateMetadata({
   params,
 }: {
-  params: { slug: string };
+  params: Promise<{ slug: string }>;
 }): Promise<Metadata> {
   try {
-    const { slug } = params;
+    const { slug } = await params;
     const post = await getBlogPost(slug);
 
     // Generate base metadata with title and description
@@ -80,10 +80,10 @@ export async function generateStaticParams() {
 export default async function BlogPostPage({
   params,
 }: {
-  params: { slug: string };
+  params: Promise<{ slug: string }>;
 }) {
   try {
-    const { slug } = params;
+    const { slug } = await params;
     const post = await getBlogPost(slug);
 
     return (

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -3,7 +3,7 @@ import { Tags } from "@/components/custom-ui/tagAndList";
 import { content } from "@/config/content";
 import { getAllBlogPosts } from "@/lib/blog";
 import { generateMetadata } from "@/lib/metadata";
-import { parseISO, format } from "date-fns";
+import { format, parseISO } from "date-fns";
 import { Calendar, Clock } from "lucide-react";
 import type { Metadata } from "next";
 import Image from "next/image";

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -56,7 +56,6 @@ export default async function Home() {
                 Contact
               </a>
             </div>
-
           </div>
         </Card>
       </section>


### PR DESCRIPTION
## Summary
- fix type definitions for `params` in blog post page
- update import order in blog page
- trim extraneous blank line in homepage

## Testing
- `pnpm run check`
- `pnpm run types`
- `pnpm run build` *(fails: EHOSTUNREACH for fonts)*