### PR TITLE
Update contact link and heading spacing

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -53,7 +53,7 @@ export default function About() {
                 href={`mailto:${person.contact.email}`}
                 className="hover:underline"
               >
-                {person.contact.email}
+                Contact
               </a>
             </div>
           </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -61,7 +61,7 @@ export default async function Home() {
       </section>
       {/* Projects Grid: Responsive layout with project cards */}
       <section className="mb-16">
-        <h2>Featured Projects</h2>
+        <h2 className="mt-6">Featured Projects</h2>
         <div className="grid gap-6 md:grid-cols-2">
           {content.home.projects.map((project) => (
             <Card key={project.title}>


### PR DESCRIPTION
## Summary
- display the email link as "Contact" on the About page
- add top margin to the Featured Projects heading for balanced spacing

## Testing
- `pnpm lint`
- `pnpm format`
- `pnpm verify`
